### PR TITLE
MIGENG-582: WMS "OS Information and recommendations"

### DIFF
--- a/src/main/java/org/jboss/xavier/analytics/functions/HelperFunctions.java
+++ b/src/main/java/org/jboss/xavier/analytics/functions/HelperFunctions.java
@@ -5,9 +5,17 @@ import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInvento
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public class HelperFunctions
 {
+    public static boolean valueMatchesAll(String value, String... match)
+    {
+        String descriptionLowerCase = value.toLowerCase();
+        return Stream.of(match).map(String::toLowerCase)
+                .allMatch(descriptionLowerCase::contains);
+    }
+
     public static int round(double value)
     {
         return (int) Math.round(value);

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
@@ -33,6 +33,7 @@ public class WorkloadInventoryReportModel
     public static final String CLUSTER_DEFAULT_VALUE = "No cluster defined";
     public static final String HOST_NAME_DEFAULT_VALUE = "No host defined";
     public static final Boolean INSIGHTS_ENABLED_DEFAULT_VALUE = false;
+    public static final String OS_FAMILY_DEFAULT_VALUE = "Other";
 
     public static final String TARGET_OCP = "OCP";
 

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/inventory/WorkloadInventoryReportModel.java
@@ -68,6 +68,7 @@ public class WorkloadInventoryReportModel
     private String host_name;
     private Boolean ssaEnabled;
     private Boolean insightsEnabled;
+    private String osFamily;
 
     public WorkloadInventoryReportModel() {}
 
@@ -259,5 +260,13 @@ public class WorkloadInventoryReportModel
 
     public void setInsightsEnabled(Boolean insightsEnabled) {
         this.insightsEnabled = insightsEnabled;
+    }
+
+    public String getOsFamily() {
+        return osFamily;
+    }
+
+    public void setOsFamily(String osFamily) {
+        this.osFamily = osFamily;
     }
 }

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/BasicFields.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/BasicFields.drl
@@ -46,10 +46,10 @@ rule "Copy basic fields and agenda controller"
         workloadInventoryReport.setCreationDate(vmWorkloadInventoryModel.getScanRunDate());
 
         insert(workloadInventoryReport);
+        kcontext.getKieRuntime().getAgenda().getAgendaGroup("OSFamily").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Workloads").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Complexity").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Targets").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Flags").setFocus();
-        kcontext.getKieRuntime().getAgenda().getAgendaGroup("OSFamily").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("ReasonableDefaults").setFocus();
 end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/BasicFields.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/BasicFields.drl
@@ -50,5 +50,6 @@ rule "Copy basic fields and agenda controller"
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Complexity").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Targets").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("Flags").setFocus();
+        kcontext.getKieRuntime().getAgenda().getAgendaGroup("OSFamily").setFocus();
         kcontext.getKieRuntime().getAgenda().getAgendaGroup("ReasonableDefaults").setFocus();
 end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
@@ -1,24 +1,34 @@
 package org.jboss.xavier.analytics.rules.workload.inventory;
 
-import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel
-import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel
+import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel;
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
 import java.util.HashSet;
+
+import function org.jboss.xavier.analytics.functions.HelperFunctions.valueMatchesAll;
 
 dialect "java"
 agenda-group "OSFamily"
 lock-on-active true
 auto-focus false
 
-function boolean osDescriptionContainsString(String osDescription, String match)
-{
-    return osDescription.toLowerCase().contains(match.toLowerCase());
-}
+rule "Fill 'osFamily' field with 'Other'"
+    salience -1
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE)
+        }
+end
 
 rule "RHEL_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "Red Hat Enterprise Linux")
+            valueMatchesAll(osDescription, "Red Hat Enterprise Linux")
         )
     then
         modify(workloadInventoryReport)
@@ -31,7 +41,7 @@ rule "SUSE_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "SUSE")
+            valueMatchesAll(osDescription, "SUSE")
         )
     then
         modify(workloadInventoryReport)
@@ -44,11 +54,11 @@ rule "Windows_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "Windows")
+            valueMatchesAll(osDescription, "Windows")
         )
     then
         String osFamily = "Windows Other";
-        if (osDescriptionContainsString(workloadInventoryReport.getOsDescription(), "Windows Server"))
+        if (valueMatchesAll(workloadInventoryReport.getOsDescription(), "Windows", "Server"))
         {
             osFamily = "Windows Server";
         }
@@ -63,7 +73,7 @@ rule "OracleLinux_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "Oracle Linux")
+            valueMatchesAll(osDescription, "Oracle Linux")
         )
     then
         modify(workloadInventoryReport)
@@ -76,7 +86,7 @@ rule "Centos_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "CentOS")
+            valueMatchesAll(osDescription, "CentOS")
         )
     then
         modify(workloadInventoryReport)
@@ -89,7 +99,7 @@ rule "Ubuntu_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "Ubuntu")
+            valueMatchesAll(osDescription, "Ubuntu")
         )
     then
         modify(workloadInventoryReport)
@@ -102,7 +112,7 @@ rule "Debian_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
             osDescription != null,
-            osDescriptionContainsString(osDescription, "Debian")
+            valueMatchesAll(osDescription, "Debian")
         )
     then
         modify(workloadInventoryReport)

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
@@ -17,7 +17,6 @@ function boolean osDescriptionContainsString(String osDescription, String match)
 rule "RHEL_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Red Hat Enterprise Linux")
         )
@@ -31,7 +30,6 @@ end
 rule "SUSE_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "SUSE")
         )
@@ -45,7 +43,6 @@ end
 rule "Windows_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Windows")
         )
@@ -65,7 +62,6 @@ end
 rule "OracleLinux_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Oracle Linux")
         )
@@ -79,7 +75,6 @@ end
 rule "Centos_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "CentOS")
         )
@@ -93,7 +88,6 @@ end
 rule "Ubuntu_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Ubuntu")
         )
@@ -107,7 +101,6 @@ end
 rule "Debian_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Debian")
         )

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
@@ -1,0 +1,112 @@
+package org.jboss.xavier.analytics.rules.workload.inventory;
+
+import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel
+import java.util.HashSet;
+
+dialect "java"
+agenda-group "Complexity"
+lock-on-active true
+auto-focus false
+
+function boolean osDescriptionContainsString(String osDescription, String match)
+{
+    return osDescription.toLowerCase().contains(match.toLowerCase());
+}
+
+rule "RHEL_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "Red Hat Enterprise Linux")
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily("RHEL")
+        }
+end
+
+rule "SUSE_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "SUSE")
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily("SUSE")
+        }
+end
+
+rule "Windows_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "Windows")
+        )
+    then
+        String osFamily = "Windows Other";
+        if (osDescriptionContainsString(workloadInventoryReport.getOsDescription(), "Windows Server"))
+        {
+            osFamily = "Windows Server";
+        }
+
+        modify(workloadInventoryReport)
+        {
+            setOsFamily(osFamily)
+        }
+end
+
+rule "OracleLinux_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "Oracle Linux")
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily("Oracle Linux")
+        }
+end
+
+rule "Centos_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "CentOS")
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily("CentOS")
+        }
+end
+
+rule "Ubuntu_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "Ubuntu")
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily("Ubuntu")
+        }
+end
+
+rule "Debian_OSFamily"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osDescription != null,
+            osDescriptionContainsString(osDescription, "Debian")
+        )
+    then
+        modify(workloadInventoryReport)
+        {
+            setOsFamily("Debian")
+        }
+end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl
@@ -5,7 +5,7 @@ import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInvento
 import java.util.HashSet;
 
 dialect "java"
-agenda-group "Complexity"
+agenda-group "OSFamily"
 lock-on-active true
 auto-focus false
 
@@ -17,6 +17,7 @@ function boolean osDescriptionContainsString(String osDescription, String match)
 rule "RHEL_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Red Hat Enterprise Linux")
         )
@@ -30,6 +31,7 @@ end
 rule "SUSE_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "SUSE")
         )
@@ -43,6 +45,7 @@ end
 rule "Windows_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Windows")
         )
@@ -62,6 +65,7 @@ end
 rule "OracleLinux_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Oracle Linux")
         )
@@ -75,6 +79,7 @@ end
 rule "Centos_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "CentOS")
         )
@@ -88,6 +93,7 @@ end
 rule "Ubuntu_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Ubuntu")
         )
@@ -101,6 +107,7 @@ end
 rule "Debian_OSFamily"
     when
         workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null,
             osDescription != null,
             osDescriptionContainsString(osDescription, "Debian")
         )

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl
@@ -79,11 +79,3 @@ rule "Fill 'osName' field with reasonable default"
        }
 end
 
-rule "Fill 'osFamily' field with 'Other'"
-    when
-        workloadInventoryReport : WorkloadInventoryReportModel(
-            osFamily == null
-        )
-    then
-        workloadInventoryReport.setOsFamily(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE);
-end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl
@@ -48,5 +48,5 @@ rule "Fill 'osFamily' field with 'Other'"
             osFamily == null
         )
     then
-        workloadInventoryReport.setOsFamily("Other");
+        workloadInventoryReport.setOsFamily(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE);
 end

--- a/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl
+++ b/src/main/resources/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl
@@ -41,3 +41,12 @@ rule "Fill 'Insights' field with reasonable default"
     then
         workloadInventoryReport.setInsightsEnabled(WorkloadInventoryReportModel.INSIGHTS_ENABLED_DEFAULT_VALUE);
 end
+
+rule "Fill 'osFamily' field with 'Other'"
+    when
+        workloadInventoryReport : WorkloadInventoryReportModel(
+            osFamily == null
+        )
+    then
+        workloadInventoryReport.setOsFamily("Other");
+end

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/OSFamilyTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/OSFamilyTest.java
@@ -1,0 +1,102 @@
+package org.jboss.xavier.analytics.rules.workload.inventory;
+
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.rules.BaseTest;
+import org.jboss.xavier.analytics.test.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OSFamilyTest extends BaseTest {
+
+    public OSFamilyTest() {
+        super("/org/jboss/xavier/analytics/rules/workload/inventory/OSFamily.drl", ResourceType.DRL,
+                "org.jboss.xavier.analytics.rules.workload.inventory", 8);
+    }
+
+    @Test
+    public void testOtherFamilyRuleShouldBeFired() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "OSFamily");
+
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("Unrecognized OSName");
+
+        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(2, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(
+                this.agendaEventListener,
+                "AgendaFocusForTest",
+                "Fill 'osFamily' field with 'Other'"
+        );
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, report.getOsFamily());
+    }
+
+    @Test
+    public void testIgnoreCase() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "OSFamily");
+
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("red hat ENTERPRISE linux");
+
+        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(2, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(
+                this.agendaEventListener,
+                "AgendaFocusForTest",
+                "RHEL_OSFamily"
+        );
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertEquals("RHEL", report.getOsFamily());
+    }
+
+    @Test
+    public void testWindowsServerFamily() {
+        Map<String, Object> facts = new HashMap<>();
+        // always add a String fact with the name of the agenda group defined in the DRL file (e.g. "SourceCosts")
+        facts.put("agendaGroup", "OSFamily");
+
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setOsDescription("Windows WHATEVER Server");
+
+        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(2, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(
+                this.agendaEventListener,
+                "AgendaFocusForTest",
+                "Windows_OSFamily"
+        );
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertEquals("Windows Server", report.getOsFamily());
+    }
+
+}

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaultsTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaultsTest.java
@@ -124,6 +124,7 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setCluster("cluster");
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
+        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -137,28 +138,6 @@ public class ReasonableDefaultsTest extends BaseTest {
         Assert.assertEquals(1, reports.size());
         WorkloadInventoryReportModel report = reports.get(0);
         Assert.assertEquals(WorkloadInventoryReportModel.OS_NAME_DEFAULT_VALUE, report.getOsName());
-    }
-
-    @Test
-    public void testOSFamilyFieldNullValueShouldFireRule() {
-        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
-        workloadInventoryReportModel.setCluster("cluster");
-        workloadInventoryReportModel.setDatacenter("datacenter");
-        workloadInventoryReportModel.setHost_name("host name");
-        workloadInventoryReportModel.setInsightsEnabled(true);
-
-        Map<String, Object> facts = new HashMap<>();
-        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
-        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
-
-        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
-        Utils.verifyRulesFiredNames(this.agendaEventListener, "Fill 'osFamily' field with 'Other'");
-
-        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
-
-        Assert.assertEquals(1, reports.size());
-        WorkloadInventoryReportModel report = reports.get(0);
-        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, report.getOsFamily());
     }
 
     @Test
@@ -177,5 +156,29 @@ public class ReasonableDefaultsTest extends BaseTest {
         Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
 
         Assert.assertEquals(0, results.get(NUMBER_OF_FIRED_RULE_KEY));
+    }
+
+    @Test
+    public void testOSFamilyFieldNullValueShouldFireRule() {
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setCluster("cluster");
+        workloadInventoryReportModel.setDatacenter("datacenter");
+        workloadInventoryReportModel.setHost_name("host name");
+        workloadInventoryReportModel.setInsightsEnabled(true);
+        workloadInventoryReportModel.setOsDescription("osDescription");
+        workloadInventoryReportModel.setOsName("osName");
+
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(this.agendaEventListener, "Fill 'osFamily' field with 'Other'");
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, report.getOsFamily());
     }
 }

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaultsTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaultsTest.java
@@ -16,7 +16,7 @@ public class ReasonableDefaultsTest extends BaseTest {
     public ReasonableDefaultsTest()
     {
         super("/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl", ResourceType.DRL,
-                "org.jboss.xavier.analytics.rules.workload.inventory", 8);
+                "org.jboss.xavier.analytics.rules.workload.inventory", 7);
     }
 
     @Test
@@ -26,7 +26,6 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
         workloadInventoryReportModel.setOsName("osName");
-        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -51,7 +50,6 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
         workloadInventoryReportModel.setOsDescription("osName");
-        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -77,7 +75,6 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setInsightsEnabled(true);
         workloadInventoryReportModel.setOsDescription("osDescription");
         workloadInventoryReportModel.setOsName("osName");
-        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -101,7 +98,6 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setHost_name("host name");
         workloadInventoryReportModel.setOsDescription("osDescription");
         workloadInventoryReportModel.setOsName("osName");
-        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -124,7 +120,6 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setCluster("cluster");
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
-        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -149,36 +144,11 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setInsightsEnabled(true);
         workloadInventoryReportModel.setOsDescription("osDescription");
         workloadInventoryReportModel.setOsName("osName");
-        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
         Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
 
         Assert.assertEquals(0, results.get(NUMBER_OF_FIRED_RULE_KEY));
-    }
-
-    @Test
-    public void testOSFamilyFieldNullValueShouldFireRule() {
-        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
-        workloadInventoryReportModel.setCluster("cluster");
-        workloadInventoryReportModel.setDatacenter("datacenter");
-        workloadInventoryReportModel.setHost_name("host name");
-        workloadInventoryReportModel.setInsightsEnabled(true);
-        workloadInventoryReportModel.setOsDescription("osDescription");
-        workloadInventoryReportModel.setOsName("osName");
-
-        Map<String, Object> facts = new HashMap<>();
-        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
-        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
-
-        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
-        Utils.verifyRulesFiredNames(this.agendaEventListener, "Fill 'osFamily' field with 'Other'");
-
-        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
-
-        Assert.assertEquals(1, reports.size());
-        WorkloadInventoryReportModel report = reports.get(0);
-        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, report.getOsFamily());
     }
 }

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaultsTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaultsTest.java
@@ -16,7 +16,7 @@ public class ReasonableDefaultsTest extends BaseTest {
     public ReasonableDefaultsTest()
     {
         super("/org/jboss/xavier/analytics/rules/workload/inventory/ReasonableDefaults.drl", ResourceType.DRL,
-                "org.jboss.xavier.analytics.rules.workload.inventory", 4);
+                "org.jboss.xavier.analytics.rules.workload.inventory", 5);
     }
 
     @Test
@@ -25,6 +25,7 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setCluster("cluster");
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
+        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -46,6 +47,7 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setDatacenter("datacenter");
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
+        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -67,6 +69,7 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setCluster("cluster");
         workloadInventoryReportModel.setDatacenter("datacenter");
         workloadInventoryReportModel.setInsightsEnabled(true);
+        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -88,6 +91,7 @@ public class ReasonableDefaultsTest extends BaseTest {
         workloadInventoryReportModel.setCluster("cluster");
         workloadInventoryReportModel.setDatacenter("datacenter");
         workloadInventoryReportModel.setHost_name("host name");
+        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
@@ -104,12 +108,35 @@ public class ReasonableDefaultsTest extends BaseTest {
     }
 
     @Test
+    public void testOSFamilyFieldNullValueShouldFireRule() {
+        WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+        workloadInventoryReportModel.setCluster("cluster");
+        workloadInventoryReportModel.setDatacenter("datacenter");
+        workloadInventoryReportModel.setHost_name("host name");
+        workloadInventoryReportModel.setInsightsEnabled(true);
+
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);
+        Map<String, Object> results = createAndExecuteCommandsAndGetResults(facts);
+
+        Assert.assertEquals(1, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Utils.verifyRulesFiredNames(this.agendaEventListener, "Fill 'osFamily' field with 'Other'");
+
+        List<WorkloadInventoryReportModel> reports = Utils.extractModels(GET_OBJECTS_KEY, results, WorkloadInventoryReportModel.class);
+
+        Assert.assertEquals(1, reports.size());
+        WorkloadInventoryReportModel report = reports.get(0);
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, report.getOsFamily());
+    }
+
+    @Test
     public void testFieldsValidValuesShouldNotFireRules() {
         WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
         workloadInventoryReportModel.setDatacenter("whatever");
         workloadInventoryReportModel.setCluster("cluster");
         workloadInventoryReportModel.setHost_name("host");
         workloadInventoryReportModel.setInsightsEnabled(true);
+        workloadInventoryReportModel.setOsFamily("OS Family");
 
         Map<String, Object> facts = new HashMap<>();
         facts.put("vmWorkloadInventoryModel", workloadInventoryReportModel);

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -78,14 +78,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default", "Fill 'osName' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -193,12 +192,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -307,12 +305,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Cpu_Affinity",
                 // Target
@@ -423,12 +420,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
        Utils.verifyRulesFiredNames(this.agendaEventListener,
             // BasicFields
             "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
-           "Fill 'osFamily' field with 'Other'",
             // Flags
            "Flag_Rdm_Disk", "Flag_Cpu_Memory_Hotplug_Memory_Add",
             // Target
@@ -534,13 +530,12 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
                 "Fill 'osDescription' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
 
                 // Target
@@ -645,12 +640,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -749,7 +743,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -757,7 +751,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -863,14 +856,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -972,14 +964,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //Reasonabledefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Cpu_Add",
                 // Target
@@ -1082,14 +1073,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Memory_Add",
                 // Target
@@ -1192,14 +1182,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Cpu_Remove",
                 // Target
@@ -1312,14 +1301,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default", "Fill 'OS' fields with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "Not_Detected_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "Fill 'osFamily' field with 'Other'"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1417,14 +1407,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default", "Fill 'OS' fields with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "Not_Detected_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "Fill 'osFamily' field with 'Other'"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1519,14 +1510,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 "Flag_Rdm_Disk", "Flag_Cpu_Memory_Hotplug_Cpu_Add",
                 // Target
@@ -1629,14 +1619,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1735,14 +1724,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1841,14 +1829,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1947,14 +1934,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2053,14 +2039,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2159,14 +2144,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2265,14 +2249,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2373,14 +2356,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2481,7 +2463,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(13, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -2489,7 +2471,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2588,12 +2569,11 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2696,14 +2676,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2803,14 +2782,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2911,14 +2889,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
 
                 // Target
@@ -3021,14 +2998,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Fill 'osFamily' field with 'Other'"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3111,7 +3089,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3119,7 +3097,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -3220,14 +3197,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Fill 'osFamily' field with 'Other'"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3318,14 +3296,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Fill 'osFamily' field with 'Other'"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3408,7 +3387,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3416,7 +3395,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP",
@@ -3518,14 +3496,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Fill 'osFamily' field with 'Other'"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3608,7 +3587,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3616,7 +3595,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -3709,7 +3687,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3717,7 +3695,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -3814,14 +3791,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -3920,14 +3896,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4026,14 +4001,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4132,14 +4106,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4238,14 +4211,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4344,14 +4316,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4458,14 +4429,13 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4547,7 +4517,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4557,7 +4527,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4608,7 +4577,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4618,7 +4587,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4668,7 +4636,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4678,7 +4646,66 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                "Target_OCP",
+                // Complexity
+                "No_Flag_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Windows_OSFamily"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Windows Server", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testWindowsServerNTFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Microsoft Windows NT Server 2008 R2 (64-bit)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4729,7 +4756,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4739,7 +4766,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4790,7 +4816,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4800,7 +4826,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -4849,7 +4874,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4859,7 +4884,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4910,7 +4934,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4920,7 +4944,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4971,7 +4994,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -4981,7 +5004,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -5030,7 +5052,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -5040,7 +5062,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'cluster' field with reasonable default",
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
-                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -78,7 +78,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(13, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -1305,13 +1305,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(6, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default", "Fill 'OS' fields with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -1357,6 +1358,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_UNKNOWN, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("Other", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1407,7 +1410,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(6, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -86,15 +86,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Insights_Enabled", "SsaEnabled_System_Services_Present", "Workloads_Oracle_JDK_8_On_Linux"
+                "Insights_Enabled", "SsaEnabled_System_Services_Present", "Workloads_Oracle_JDK_8_On_Linux",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -123,8 +123,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -142,7 +140,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertTrue(workloadInventoryReportModel.getInsightsEnabled());
         Assert.assertEquals(1, workloads.size());
         Assert.assertTrue(workloads.contains("Oracle JDK 8"));
-
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -200,8 +199,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -209,7 +206,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present", "Workloads_Oracle_JDK_11_On_Linux"
+                "SsaEnabled_System_Services_Present", "Workloads_Oracle_JDK_11_On_Linux",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -238,8 +237,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -258,6 +255,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertFalse(workloadInventoryReportModel.getInsightsEnabled());
         Assert.assertEquals(1, workloads.size());
         Assert.assertTrue(workloads.contains("Oracle JDK 11"));
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -314,8 +313,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Affinity",
                 // Target
@@ -323,7 +320,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present", "Workloads_Oracle_JDK_13_On_Linux"
+                "SsaEnabled_System_Services_Present", "Workloads_Oracle_JDK_13_On_Linux",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -352,8 +351,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -371,6 +368,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
         Assert.assertEquals(1, workloads.size());
         Assert.assertTrue(workloads.contains("Oracle JDK 13"));
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -430,8 +429,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
             // BasicFields
             "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
            "Fill 'osFamily' field with 'Other'",
-           // OSFamily
-           "RHEL_OSFamily",
             // Flags
            "Flag_Rdm_Disk", "Flag_Cpu_Memory_Hotplug_Memory_Add",
             // Target
@@ -439,7 +436,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
             // Complexity
            "More_Than_One_Flag_Supported_OS",
            // Workloads
-           "SsaEnabled_System_Services_Present"
+           "SsaEnabled_System_Services_Present",
+           // OSFamily
+           "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -468,8 +467,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -484,6 +481,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_HARD, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -541,8 +540,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "OracleLinux_OSFamily",
                 // Flags
 
                 // Target
@@ -550,7 +547,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Convertible_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "OracleLinux_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -579,8 +578,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("Oracle Linux", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -594,6 +591,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         //Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_MEDIUM, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("Oracle Linux", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -651,8 +650,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Centos_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -660,7 +657,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Or_More_Flags_Convertible_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "Centos_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -689,8 +688,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("CentOS", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertEquals(1, flagsIMS.size());
@@ -703,6 +700,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_HARD, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("CentOS", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -758,8 +757,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Debian_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -767,7 +764,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Or_More_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "Debian_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -797,8 +796,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
-        // OSFamily
-        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -812,6 +809,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_UNSUPPORTED, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -871,15 +870,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -908,8 +907,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -923,6 +920,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_EASY, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -980,8 +979,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //Reasonabledefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Cpu_Add",
                 // Target
@@ -989,7 +986,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1018,8 +1017,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1033,6 +1030,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_MEDIUM, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1090,8 +1089,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Memory_Add",
                 // Target
@@ -1099,7 +1096,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1128,8 +1127,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1143,6 +1140,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_MEDIUM, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1200,8 +1199,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Cpu_Remove",
                 // Target
@@ -1209,7 +1206,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "One_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1238,8 +1237,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1253,6 +1250,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_MEDIUM, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1348,8 +1347,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -1360,6 +1357,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_UNKNOWN, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1422,8 +1421,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk", "Flag_Cpu_Memory_Hotplug_Cpu_Add",
                 // Target
@@ -1431,7 +1428,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "More_Than_One_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Tomcat", "SsaEnabled_System_Services_Present"
+                "Workloads_Tomcat", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1460,8 +1459,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1478,6 +1475,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("tomcat")));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1532,15 +1531,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_EAP", "SsaEnabled_System_Services_Present"
+                "Workloads_EAP", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1569,8 +1568,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1584,6 +1581,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Red Hat JBoss EAP".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1638,15 +1637,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Websphere", "SsaEnabled_System_Services_Present"
+                "Workloads_Websphere", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1688,6 +1687,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("IBM Websphere App Server".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1742,15 +1743,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Weblogic", "SsaEnabled_System_Services_Present"
+                "Workloads_Weblogic", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1779,8 +1780,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1794,6 +1793,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Oracle Weblogic".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1848,15 +1849,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Oracle_DB", "SsaEnabled_System_Services_Present"
+                "Workloads_Oracle_DB", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1885,8 +1886,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1900,6 +1899,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Oracle Database".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -1954,15 +1955,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Clickhouse_Server", "SsaEnabled_System_Services_Present"
+                "Workloads_Clickhouse_Server", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -1991,8 +1992,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2006,6 +2005,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Clickhouse Server".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -2060,15 +2061,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_SAP_HANA", "SsaEnabled_System_Services_Present"
+                "Workloads_SAP_HANA", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2097,8 +2098,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2112,6 +2111,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("SAP HANA".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -2166,15 +2167,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Microsoft_SQL_Server_On_Linux", "SsaEnabled_System_Services_Present"
+                "Workloads_Microsoft_SQL_Server_On_Linux", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2203,8 +2204,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2218,6 +2217,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Microsoft SQL Server".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -2274,15 +2275,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Microsoft_SQL_Server_On_Windows", "SsaEnabled_System_Services_Present"
+                "Workloads_Microsoft_SQL_Server_On_Windows", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2311,8 +2312,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2326,6 +2325,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Microsoft SQL Server".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
 
@@ -2383,15 +2384,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Microsoft_SQL_Server_On_Windows", "SsaEnabled_System_Services_Present"
+                "Workloads_Microsoft_SQL_Server_On_Windows", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2421,8 +2422,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2435,6 +2434,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertNotNull(workloadInventoryReportModel.getWorkloads());
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Microsoft SQL Server".toLowerCase())));
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -2487,15 +2488,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Artifactory", "SsaEnabled_System_Services_Present"
+                "Workloads_Artifactory", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2526,8 +2527,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
         //
         Assert.assertEquals(WorkloadInventoryReportModel.INSIGHTS_ENABLED_DEFAULT_VALUE,workloadInventoryReportModel.getInsightsEnabled());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2541,6 +2540,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Artifactory".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -2597,15 +2598,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_F5", "SsaEnabled_System_Services_Present"
+                "Workloads_F5", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2634,8 +2635,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2649,6 +2648,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("F5".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -2704,15 +2705,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaEnabled_System_Services_Present"
+                "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2741,8 +2742,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2754,6 +2753,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         // Workloads
         Assert.assertNull(workloadInventoryReportModel.getWorkloads());
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
 
@@ -2812,8 +2813,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
 
                 // Target
@@ -2821,7 +2820,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2850,8 +2851,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2862,6 +2861,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_EASY, workloadInventoryReportModel.getComplexity());
         // Workloads
         Assert.assertFalse(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
 
@@ -3012,15 +3013,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Ubuntu_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Ubuntu_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3050,8 +3051,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
-        // OSFamily
-        Assert.assertEquals("Ubuntu", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3062,6 +3061,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         // Complexity
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_UNSUPPORTED, workloadInventoryReportModel.getComplexity());
         // Workloads
+        // OSFamily
+        Assert.assertEquals("Ubuntu", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -3309,15 +3310,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "SUSE_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "SUSE_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3347,8 +3348,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
-        // OSFamily
-        Assert.assertEquals("SUSE", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3360,6 +3359,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         // Complexity
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_EASY, workloadInventoryReportModel.getComplexity());
         // Workloads
+        // OSFamily
+        Assert.assertEquals("SUSE", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -3509,15 +3510,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Windows_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Windows_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3547,8 +3548,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
-        // OSFamily
-        Assert.assertEquals("Windows Other", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3559,6 +3558,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         // Complexity
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_UNSUPPORTED, workloadInventoryReportModel.getComplexity());
         // Workloads
+        // OSFamily
+        Assert.assertEquals("Windows Other", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -3610,15 +3611,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Debian_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Debian_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3648,8 +3649,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
-        // OSFamily
-        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3660,6 +3659,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         // Complexity
         Assert.assertEquals(WorkloadInventoryReportModel.COMPLEXITY_UNSUPPORTED, workloadInventoryReportModel.getComplexity());
         // Workloads
+        // OSFamily
+        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -3714,15 +3715,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present"
+                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3751,8 +3752,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3766,6 +3765,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Citrix Unidesk".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -3820,15 +3821,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present"
+                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3857,8 +3858,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3872,6 +3871,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Citrix Unidesk".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -3926,15 +3927,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present"
+                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -3963,8 +3964,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3978,6 +3977,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Citrix Unidesk".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -4032,15 +4033,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present"
+                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4069,8 +4070,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -4084,6 +4083,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Citrix Unidesk".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -4138,15 +4139,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present"
+                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4175,8 +4176,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -4190,6 +4189,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Citrix Unidesk".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -4244,15 +4245,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present"
+                "Workloads_Citrix_Unidesk", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4281,8 +4282,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -4296,6 +4295,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(1, workloadInventoryReportModel.getWorkloads().size());
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Citrix Unidesk".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -4358,15 +4359,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Cisco_CallManager", "Insights_Enabled", "SsaEnabled_System_Services_Present"
+                "Workloads_Cisco_CallManager", "Insights_Enabled", "SsaEnabled_System_Services_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4395,8 +4396,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
-        // OSFamily
-        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -4411,6 +4410,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertTrue(workloadInventoryReportModel.getWorkloads().stream().anyMatch(workload -> workload.toLowerCase().contains("Cisco CallManager".toLowerCase())));
         Assert.assertTrue(workloadInventoryReportModel.getInsightsEnabled());
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
     }
 
     @Test
@@ -4450,8 +4451,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4460,7 +4459,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "RHEL_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4511,8 +4512,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "SUSE_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4520,7 +4519,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "SUSE_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4571,8 +4572,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Windows_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4581,7 +4580,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Windows_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4632,8 +4633,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Windows_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4642,7 +4641,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Windows_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4693,15 +4694,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Windows_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Windows_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4752,8 +4753,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "OracleLinux_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4762,7 +4761,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Convertible_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "OracleLinux_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4813,8 +4814,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Centos_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV",
@@ -4823,7 +4822,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // Complexity
                 "No_Flag_Convertible_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Centos_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4874,15 +4875,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Ubuntu_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Ubuntu_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -4933,15 +4934,15 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
                 "Fill 'osFamily' field with 'Other'",
-                // OSFamily
-                "Debian_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
                 // Complexity
                 "No_Flags_Not_Supported_OS",
                 // Workloads
-                "SsaDisabled_System_Services_Not_Present"
+                "SsaDisabled_System_Services_Not_Present",
+                // OSFamily
+                "Debian_OSFamily"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -25,7 +25,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
 
     public WorkloadInventoryReportTest()
     {
-        super("WorkloadInventoryKSession0", "org.jboss.xavier.analytics.rules.workload.inventory.*", 44);
+        super("WorkloadInventoryKSession0", "org.jboss.xavier.analytics.rules.workload.inventory.*", 52);
     }
 
     @Test
@@ -78,13 +78,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -120,6 +123,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -189,11 +194,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -230,6 +238,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -298,11 +308,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Affinity",
                 // Target
@@ -339,6 +352,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -409,11 +424,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
        Utils.verifyRulesFiredNames(this.agendaEventListener,
             // BasicFields
             "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
+           "Fill 'osFamily' field with 'Other'",
+           // OSFamily
+           "RHEL_OSFamily",
             // Flags
            "Flag_Rdm_Disk", "Flag_Cpu_Memory_Hotplug_Memory_Add",
             // Target
@@ -450,6 +468,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -515,11 +535,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "OracleLinux_OSFamily",
                 // Flags
 
                 // Target
@@ -556,6 +579,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("Oracle Linux", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -620,11 +645,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Centos_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -661,6 +689,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("CentOS", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertEquals(1, flagsIMS.size());
@@ -719,7 +749,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -727,6 +757,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Debian_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk",
                 // Target
@@ -764,6 +797,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        // OSFamily
+        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -828,13 +863,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -870,6 +908,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -932,13 +972,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(6, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //Reasonabledefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Cpu_Add",
                 // Target
@@ -975,6 +1018,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1037,13 +1082,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(6, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Memory_Add",
                 // Target
@@ -1080,6 +1128,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1142,13 +1192,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(6, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 "Flag_Cpu_Memory_Hotplug_Cpu_Remove",
                 // Target
@@ -1185,6 +1238,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1250,13 +1305,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(5, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(6, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -1292,6 +1348,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -1356,13 +1414,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 "Flag_Rdm_Disk", "Flag_Cpu_Memory_Hotplug_Cpu_Add",
                 // Target
@@ -1399,6 +1460,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNotNull(flagsIMS);
@@ -1461,13 +1524,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1503,6 +1569,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1562,13 +1630,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1663,13 +1734,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1705,6 +1779,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1764,13 +1840,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1806,6 +1885,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1865,13 +1946,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -1907,6 +1991,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -1966,13 +2052,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2008,6 +2097,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2067,13 +2158,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2109,6 +2203,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2170,13 +2266,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2212,6 +2311,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2273,7 +2374,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(13, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -2281,13 +2382,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
                 // Complexity
                 "No_Flag_Supported_OS",
                 // Workloads
-                "Workloads_Microsoft_SQL_Server_On_Windows","SsaEnabled_System_Services_Present"
+                "Workloads_Microsoft_SQL_Server_On_Windows", "SsaEnabled_System_Services_Present"
         );
 
         // retrieve the QueryResults that was available in the working memory from the results
@@ -2317,6 +2421,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2375,11 +2481,14 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller", "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2417,6 +2526,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
         //
         Assert.assertEquals(WorkloadInventoryReportModel.INSIGHTS_ENABLED_DEFAULT_VALUE,workloadInventoryReportModel.getInsightsEnabled());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2478,13 +2589,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2520,6 +2634,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2580,13 +2696,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -2622,6 +2741,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2683,13 +2804,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(7, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
 
                 // Target
@@ -2726,6 +2850,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -2780,7 +2906,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -2788,6 +2914,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -2824,6 +2951,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -2854,7 +2982,6 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         vmWorkloadInventoryModel.setProduct("VMware vCenter");
         vmWorkloadInventoryModel.setVersion("6.5");
         vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
-
         //Flags
 
         Map<String, String> files = new HashMap<>();
@@ -2876,7 +3003,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -2884,6 +3011,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Ubuntu_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
@@ -2920,6 +3050,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        // OSFamily
+        Assert.assertEquals("Ubuntu", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -2972,7 +3104,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -2980,6 +3112,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -3016,6 +3149,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3068,7 +3202,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3076,6 +3210,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -3112,6 +3247,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3164,7 +3300,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3172,6 +3308,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "SUSE_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP",
@@ -3208,6 +3347,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        // OSFamily
+        Assert.assertEquals("SUSE", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3261,7 +3402,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3269,6 +3410,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
                 // Flags
                 // Target
                 "Target_None",
@@ -3305,6 +3447,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        Assert.assertEquals(WorkloadInventoryReportModel.OS_FAMILY_DEFAULT_VALUE, workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3357,7 +3500,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3365,6 +3508,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Windows_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
@@ -3401,6 +3547,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        // OSFamily
+        Assert.assertEquals("Windows Other", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3453,7 +3601,7 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
@@ -3461,6 +3609,9 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
                 // ReasonableDefaults
                 "Fill 'datacenter' field with reasonable default", "Fill 'cluster' field with reasonable default", "Fill 'host_name' field with reasonable default",
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Debian_OSFamily",
                 // Flags
                 // Target
                 "Target_None",
@@ -3497,6 +3648,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals(WorkloadInventoryReportModel.DATACENTER_DEFAULT_VALUE, workloadInventoryReportModel.getDatacenter());
         Assert.assertEquals(WorkloadInventoryReportModel.CLUSTER_DEFAULT_VALUE, workloadInventoryReportModel.getCluster());
         Assert.assertEquals(WorkloadInventoryReportModel.HOST_NAME_DEFAULT_VALUE, workloadInventoryReportModel.getHost_name());
+        // OSFamily
+        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
         // Flags
         Set<String> flagsIMS = workloadInventoryReportModel.getFlagsIMS();
         Assert.assertNull(flagsIMS);
@@ -3553,13 +3706,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -3595,6 +3751,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3654,13 +3812,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -3696,6 +3857,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3755,13 +3918,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -3797,6 +3963,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3856,13 +4024,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -3898,6 +4069,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -3957,13 +4130,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -3999,6 +4175,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -4058,13 +4236,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(8, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4100,6 +4281,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());
@@ -4167,13 +4350,16 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
 
         // check that the number of rules fired is what you expect
-        Assert.assertEquals(9, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
         // check the names of the rules fired are what you expect
         Utils.verifyRulesFiredNames(this.agendaEventListener,
                 // BasicFields
                 "Copy basic fields and agenda controller",
                 //ReasonableDefaults
                 "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
                 // Flags
                 // Target
                 "Target_RHV", "Target_OSP", "Target_OCP",
@@ -4209,6 +4395,8 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertEquals("6.5", workloadInventoryReportModel.getVersion());
         Assert.assertEquals("esx13.v2v.bos.redhat.com", workloadInventoryReportModel.getHost_name());
         Assert.assertEquals(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"), workloadInventoryReportModel.getCreationDate());
+        // OSFamily
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
         // Flags
         // Targets
         Assert.assertEquals(3, workloadInventoryReportModel.getRecommendedTargetsIMS().size());

--- a/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
+++ b/src/test/java/org/jboss/xavier/analytics/rules/workload/inventory/WorkloadInventoryReportTest.java
@@ -4412,4 +4412,546 @@ public class WorkloadInventoryReportTest extends BaseIntegrationTest {
         Assert.assertTrue(workloadInventoryReportModel.getInsightsEnabled());
         Assert.assertTrue(workloadInventoryReportModel.getSsaEnabled());
     }
+
+    @Test
+    public void testRHELFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Red Hat Enterprise Linux Server release 7.6 (Maipo)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "RHEL_OSFamily",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                "Target_OCP",
+                // Complexity
+                "No_Flag_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("RHEL", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testSUSEFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("SUSE");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(11, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "SUSE_OSFamily",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                // Complexity
+                "No_Flag_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("SUSE", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testWindowsServerFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Microsoft Windows Server 2008 R2 (64-bit)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Windows_OSFamily",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                "Target_OCP",
+                // Complexity
+                "No_Flag_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Windows Server", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testWindowsOtherFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Microsoft Windows 8.x (64-bit)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Windows_OSFamily",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                "Target_OCP",
+                // Complexity
+                "No_Flag_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Windows Other", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testWindowsOtherFamily_XP() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Microsoft Windows XP Professional (32-bit)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Windows_OSFamily",
+                // Flags
+                // Target
+                "Target_None",
+                // Complexity
+                "No_Flags_Not_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Windows Other", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testOracleLinuxFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Oracle Linux 8");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "OracleLinux_OSFamily",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                "Target_RHEL",
+                // Complexity
+                "No_Flag_Convertible_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Oracle Linux", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testCentOSFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("CentOS Linux release 7.6.1810 (Core)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(12, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Centos_OSFamily",
+                // Flags
+                // Target
+                "Target_RHV",
+                "Target_OSP",
+                "Target_RHEL",
+                // Complexity
+                "No_Flag_Convertible_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("CentOS", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testUbuntuFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Ubuntu Linux (64-bit)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Ubuntu_OSFamily",
+                // Flags
+                // Target
+                "Target_None",
+                // Complexity
+                "No_Flags_Not_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Ubuntu", workloadInventoryReportModel.getOsFamily());
+    }
+
+    @Test
+    public void testDebianFamily() throws ParseException {
+        //Basic Fields
+        VMWorkloadInventoryModel vmWorkloadInventoryModel = new VMWorkloadInventoryModel();
+
+        vmWorkloadInventoryModel.setProvider("provider");
+        vmWorkloadInventoryModel.setVmName("vmName");
+        vmWorkloadInventoryModel.setDiskSpace(100000001L);
+        vmWorkloadInventoryModel.setMemory(4096L);
+        vmWorkloadInventoryModel.setCpuCores(4);
+        vmWorkloadInventoryModel.setGuestOSFullName("Debian 8 (64-bit)");
+        vmWorkloadInventoryModel.setOsProductName("productName");
+        vmWorkloadInventoryModel.setProduct("product");
+        vmWorkloadInventoryModel.setVersion("6.5");
+        vmWorkloadInventoryModel.setScanRunDate(new SimpleDateFormat("yyyy-M-dd'T'hh:mm:ss.S").parse("2019-09-18T14:52:45.871Z"));
+
+        // define the list of commands you want to be executed by Drools
+        Map<String, Object> facts = new HashMap<>();
+        facts.put("vmWorkloadInventoryModel", vmWorkloadInventoryModel);
+        List<Command> commands = new ArrayList<>();
+        commands.addAll(Utils.newInsertCommands(facts));
+        commands.add(CommandFactory.newFireAllRules(NUMBER_OF_FIRED_RULE_KEY));
+        commands.add(CommandFactory.newQuery(QUERY_IDENTIFIER, "GetWorkloadInventoryReports"));
+        Map<String, Object> results = Utils.executeCommandsAndGetResults(kieSession, commands);
+
+        // check that the number of rules fired is what you expect
+        Assert.assertEquals(10, results.get(NUMBER_OF_FIRED_RULE_KEY));
+        // check the names of the rules fired are what you expect
+        Utils.verifyRulesFiredNames(this.agendaEventListener,
+                // BasicFields
+                "Copy basic fields and agenda controller",
+                // ReasonableDefaults
+                "Fill 'datacenter' field with reasonable default",
+                "Fill 'cluster' field with reasonable default",
+                "Fill 'host_name' field with reasonable default",
+                "Fill 'Insights' field with reasonable default",
+                "Fill 'osFamily' field with 'Other'",
+                // OSFamily
+                "Debian_OSFamily",
+                // Flags
+                // Target
+                "Target_None",
+                // Complexity
+                "No_Flags_Not_Supported_OS",
+                // Workloads
+                "SsaDisabled_System_Services_Not_Present"
+        );
+
+        // retrieve the QueryResults that was available in the working memory from the results
+        QueryResults queryResults= (QueryResults) results.get(QUERY_IDENTIFIER);
+        Assert.assertEquals(1, queryResults.size());
+
+        QueryResultsRow queryResultsRow = queryResults.iterator().next();
+        Assert.assertThat(queryResultsRow.get("report"), instanceOf(WorkloadInventoryReportModel.class));
+
+        WorkloadInventoryReportModel workloadInventoryReportModel = (WorkloadInventoryReportModel) queryResultsRow.get("report");
+        Assert.assertEquals("Debian", workloadInventoryReportModel.getOsFamily());
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-582

- Added a new field in `WorkloadInventoryReportModel` called `osFamily`
- Added a new `.drl` file which uses the new agenda-group `OSFamily`
- the new `osFamily` field of `WorkloadInventoryReportModel` will be populated with the values below and it will be inferred from the OSDescription.

1. RHEL
1. Windows Server
1. Windows Other
1. SUSE
1. CentOS
1. Oracle Linux
1. Ubuntu
1. Debian
1. Other